### PR TITLE
Add open-source baseline files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = off
+
+[Makefile]
+indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/.gitignore         @rezwanx
+**/.gitignore       @rezwanx
+/.gitattributes     @rezwanx
+/.github/workflows/ @rezwanx

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+
+# --- open-source baseline: secrets, build output, local agent files ---
+.env
+.env.*
+!.env.example
+node_modules/
+bin/
+obj/
+dist/
+build/
+out/
+coverage/
+CLAUDE.md
+AGENTS.md
+GEMINI.md
+QWEN.md
+.cursorrules
+.clinerules
+.windsurfrules
+graphify-out/
+results/
+.sonarqube/
+scripts/scan.sh
+*-secrets.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,49 @@
+# gitleaks configuration for this repository.
+#
+# Starts from the upstream default rule set and adds a narrow allowlist for the
+# categories that are documentation, test fixtures, or generated manifests. The
+# allowlist is deliberately specific: it matches placeholder shapes and known
+# non-secret file layouts, not whole directories of real code.
+#
+# Run locally with: gitleaks dir . --config .gitleaks.toml
+#                   gitleaks git . --config .gitleaks.toml
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documentation placeholders, test fixtures, and generated manifests"
+
+paths = [
+  # Release manifests: one container image tag per line. The tag suffix is a build
+  # hash, which trips the generic high-entropy rules.
+  '''(^|/)blocks-[a-z0-9-]+/(api|worker)/(prod|stg|enterprise)\.txt$''',
+
+  # Secret-detection source: this file contains the regexes used to find private
+  # keys, so it necessarily looks like it contains one.
+  '''(^|/)guardrail_validator\.py$''',
+
+  # Frontend and backend unit tests use fabricated credentials as fixtures.
+  '''\.test\.(ts|tsx|js|jsx)$''',
+  '''(^|/)XUnitTest/.*Tests\.cs$''',
+]
+
+regexes = [
+  # Environment variable references, not values: $TOKEN, ${SONAR_GET}, $API_BASE_URL.
+  # A real credential never contains "${...}", so treat any such capture as a reference.
+  '''^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$''',
+  '''\$\{[A-Za-z_][A-Za-z0-9_]*\}''',
+
+  # Documentation placeholders.
+  # A value containing an ellipsis is an elided example (for example "eyJhbGci..."),
+  # not a usable credential.
+  '''\.\.\.''',
+  '''YOUR_[A-Z_]+''',
+  '''<your-[a-z-]+>''',
+  '''TEST_KEY_[0-9]+''',
+  '''^(test|fake|dummy|sample|example|placeholder|changeme|redacted)[-_A-Za-z0-9]*$''',
+  '''^sk-(test|fake|dummy)''',
+
+  # Container image tag suffix: <short-sha>-<build>-<calver>.
+  '''^[0-9a-f]{7,}-[0-9]+-[0-9]+\.[0-9]+\.?[0-9]*$''',
+]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we, as contributors and maintainers, pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [contact-email]. All complaints will be reviewed and investigated, and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq).
+
+[contact-email]: mailto:blocks@selisegroup.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Blocks OS
+
+Thanks for contributing. This guide covers the day-to-day workflow for this repository. See `README.md` for environment setup.
+
+## Branch model
+
+- `main`: production-ready code (protected)
+- `dev`: integration branch (protected); all pull requests target `dev`
+- `inception`: the working branch; day-to-day work happens here
+
+Never commit directly to `dev` or `main`. Work on `inception` and open a pull request from `inception` into `dev`. Do not force-push and do not rewrite published history.
+
+## Commit conventions
+
+Match the style already in the log. Most commits use Conventional Commits (`type(scope): subject`, for example `test(client): ...`, `chore(e2e): ...`); a plain imperative subject is also used for straightforward changes. Keep the subject concise and explain the what and the why in the body when it is not obvious.
+
+## Reporting a security issue
+
+Do not open a public issue for a suspected vulnerability. Follow the private disclosure process in [SECURITY.md](SECURITY.md).
+
+## Repository layout
+
+- `server/`: .NET backend (`Api`, `Worker`, and the `*.DomainService` projects). Tests live in `server/XUnitTest`.
+- `client/`: React + TypeScript + Vite frontend. Tests are colocated next to the code they cover.
+- `.github/workflows/`: CI pipelines (`ci-dev.yml`, `ci-stg.yml`, `ci_prod.yml`).
+
+## Running the tests
+
+Both suites must pass before a PR can merge.
+
+Backend:
+
+```bash
+dotnet test server/XUnitTest/XUnitTest.csproj
+```
+
+Frontend (from `client/`):
+
+```bash
+npm ci
+npx vitest run          # single run
+npm run test:watch      # watch mode
+npm run test:coverage   # with coverage report
+```
+
+The frontend runner is configured in `client/vitest.config.ts` (separate from `vite.config.ts`).
+
+## Continuous integration
+
+On pull requests, the `RUN_TESTS` flag enables PR-only jobs that run the backend suite (via the shared reusable workflow, which handles private NuGet auth) and the frontend suite (`npx vitest run`). Keep both green.
+
+## Naming conventions
+
+Follow the conventions the code already uses when adding code. There is no lint/analyzer enforcement of these yet:
+
+- Backend (C#): interfaces are `I`-prefixed; types and public members are PascalCase; parameters and locals are camelCase; private fields are `_camelCase`; `Task`-returning methods carry the `Async` suffix; request/response DTOs end in `Request`/`Response`.
+- Frontend (TypeScript): files and folders are kebab-case (`use-*.ts` hooks, `*.service.ts` services); types and React components are PascalCase; variables and functions are camelCase.
+
+## Backward-compatible renames
+
+The public API and wire contract are consumed by other services and clients. When renaming anything public, keep the old form working:
+
+- C# method/type: keep the old symbol, mark it `[Obsolete("Renamed to <New>.")]`, and forward to the new one.
+- C# route/action: add the new action, keep the old one marked `[Obsolete]` delegating to the new, never delete a route.
+- JSON field: add the correctly-named member and keep accepting the old name.
+- TypeScript export: `/** @deprecated use <new> */ export const oldName = newName;`.
+- Permission scopes are grant-breaking: never silently change a scope string; changes need a coordinated per-tenant grant migration.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SELISE Digital Platforms
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-# blockscloud-inventory
+# blocks-inventory
+
+Release inventory for the SELISE `<Blocks/>` platform. This repository is the ledger of published
+container image tags: for every service it records which image versions exist per component (API
+and worker) and per environment (production, staging, enterprise), together with the GitHub
+Actions workflows that build, scan, and roll those images out.
+
+## Overview
+
+The repository holds no application code. It is a manifest and CI repository:
+
+- One directory per service (for example `blocks-idp-net/`, `blocks-localization-net/`), each with
+  an `api/` and a `worker/` subdirectory.
+- Inside those, one text file per environment (`prod.txt`, `stg.txt`, `enterprise.txt`) listing the
+  published image tags in chronological order, one `repository/image:tag` per line.
+- `.github/workflows/`: the shared unit test, SAST, SCA, and DAST pipelines plus the build, push,
+  and GitOps deployment workflows.
+- `.github/config/values-config.json` and `.github/actions/setvars/`: shared configuration and the
+  variable-setup composite action used by those workflows.
+
+## Repository structure
+
+```
+blocks-inventory/
+├── blocks-<service>-net/
+│   ├── api/
+│   │   ├── prod.txt          # published API image tags, one per line
+│   │   ├── stg.txt
+│   │   └── enterprise.txt
+│   └── worker/
+│       └── ...               # same layout for the worker image
+├── .github/
+│   ├── actions/setvars/      # composite action shared by the workflows
+│   ├── config/               # shared workflow configuration
+│   └── workflows/            # unit test, SAST, SCA, DAST, build, push, deployment
+├── LICENSE
+└── README.md
+```
+
+## Getting started
+
+There is nothing to build or run. To read the current state of a service, open the relevant file:
+
+```bash
+tail -5 blocks-idp-net/api/prod.txt      # the most recent production API images
+```
+
+## How entries are added
+
+Tags are appended by the release workflows, not by hand. A new line appears when a build is
+promoted to that environment, so the last line of a file is the current version. Avoid editing or
+reordering existing lines: the history of the file is the release history.
+
+## Configuration
+
+The workflows read their settings from `.github/config/values-config.json` and from repository and
+organization level Actions variables and secrets. No credentials are stored in this repository, and
+none should be added: registry and deployment credentials belong in GitHub secrets.
+
+## Contributing and security
+
+- Contribution conventions and workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Reporting a vulnerability: [SECURITY.md](SECURITY.md)
+- Community standards: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+## License
+
+See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest code on the default branch. Older commits, tags, and forks are not maintained; please reproduce findings against the most recent code before reporting.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability, please report it to us as soon as possible. We take all reports seriously and will do our best to address the issue promptly.
+
+**Do not create a public GitHub issue for the security vulnerability.**
+
+Instead, please follow these steps:
+
+1. Email us at [blocks@selisegroup.com](mailto:blocks@selisegroup.com) with details of the vulnerability.
+2. Include a thorough description of the issue, including any relevant information on the environment in which the vulnerability was discovered.
+3. Allow some time for us to review and respond to your report.
+
+## What to Expect
+
+- We aim to acknowledge new reports within a few business days.
+- We will work with you to understand and validate the issue, and keep you informed while a fix is prepared.
+- Please keep the details of the report confidential until a fix is released.
+
+## Responsible Disclosure
+
+We appreciate the efforts of security researchers and the community in helping to keep our project and users safe. If you responsibly disclose a security issue, we commit to:
+
+- Acknowledge and respond to your report promptly.
+- Work with you to understand and validate the issue.
+- Provide details on when and how the issue will be addressed.
+- Give credit to the reporter, if agreed upon, upon resolution of the issue.
+
+## Scope
+
+This security policy applies to the **SELISE `<Blocks/>`** project. Please note that this policy does not give you permission to hack, harm, or exploit our services. Any such attempts will be considered malicious and may be reported to the appropriate authorities.
+
+## Updates
+
+We may update this security policy from time to time. Check the file's Git history for the most recent changes.
+
+Thank you for helping to keep **SELISE `<Blocks/>`** secure!
+


### PR DESCRIPTION
Adds the governance, tooling and hygiene files these repositories need before going public.

Per repo, only what was missing:

- `LICENSE` (MIT), `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
- `.editorconfig`, `.github/CODEOWNERS`, `.dockerignore` where a container is built
- `.gitleaks.toml`: upstream default rules, no allowlisting of real findings
- `.env.example`: key names only, every value blank
- `.gitignore`: extended to cover `.env*`, build output, and local agent instruction files
- `README.md`: standard "Contributing and security" and "License" sections

No functional code changes. Conventions follow blocks-iam and blocks-os.