### PR TITLE
Complete the local and agent file ignore rules

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,0 +1,16 @@
+name: repo-hygiene
+on:
+  push:
+    branches: [inception]
+  pull_request:
+    branches: [inception]
+jobs:
+  repo-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: no stray markdown or AI artifacts
+        run: |
+          badmd=$(git ls-files '*.md' | grep -vE '(^|/)(README|LICENSE|CONTRIBUTING|SECURITY|CODE_OF_CONDUCT)\.md$' || true)
+          badai=$(git ls-files | grep -iE '(^|/)(\.claude|\.cursor|\.codex|\.hermes|\.aider|\.windsurf|\.gemini|\.kiro|\.trae|graphify-out)(/|$)|(^|/)(\.cursorrules|\.mcp\.json|copilot-instructions\.md)$' || true)
+          if [ -n "$badmd$badai" ]; then echo "Policy violations:"; echo "$badmd"; echo "$badai"; exit 1; fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+
+# --- AI assistant artifacts: never track ---
+.claude/
+.cursor/
+.codex/
+.hermes/
+.aider*
+.windsurf/
+.gemini/
+.kiro/
+.trae/
+graphify-out/
+CLAUDE.md
+GEMINI.md
+AGENTS.md
+.cursorrules
+.mcp.json
+copilot-instructions.md
+
+# --- markdown policy: only standard docs tracked ---
+*.md
+!README.md
+!LICENSE.md
+!CONTRIBUTING.md
+!SECURITY.md
+!CODE_OF_CONDUCT.md

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,11 @@ scripts/scan.sh
 QWEN.md
 .clinerules
 .windsurfrules
+
+# --- local tooling scripts (Windows + bash) - do not commit ---
+scripts/scan.ps1
+scripts/deploy.sh
+scripts/deploy.ps1
+scripts/th_transform.py
+scripts/secrets.local.ps1
+deploy.log

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,17 @@ copilot-instructions.md
 !CONTRIBUTING.md
 !SECURITY.md
 !CODE_OF_CONDUCT.md
+
+# --- local AI / scan workspace (do not commit) ---
+results/
+.sonarqube/
+scripts/scan.sh
+*-secrets.json
+.env
+.env.*
+!.env.example
+
+# --- AI agent instruction files (do not commit) ---
+QWEN.md
+.clinerules
+.windsurfrules

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we, as contributors and maintainers, pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [contact-email]. All complaints will be reviewed and investigated, and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq).
+
+[contact-email]: mailto:blocks@selisegroup.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing to blocks-genesis-net
+
+Thank you for your interest in contributing to **blocks-genesis-net**! Your contributions help improve this project for everyone. Whether you're reporting a bug, suggesting an enhancement, or submitting code changes, we welcome your input.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [How to Contribute](#how-to-contribute)
+  - [Reporting Issues](#reporting-issues)
+  - [Submitting Pull Requests](#submitting-pull-requests)
+- [Branching Strategy](#branching-strategy)
+- [Git Guidelines](#git-guidelines)
+- [Coding Guidelines](#coding-guidelines)
+- [Code Review Process](#code-review-process)
+- [License](#license)
+
+## Code of Conduct
+
+Please read and follow our [Code of Conduct](./CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms.
+
+## How to Contribute
+
+### Reporting Issues
+
+If you encounter a bug or any issue, please report it by [opening an issue](https://github.com/SELISEdigitalplatforms/blocks-genesis-net/issues/new) and include the following details:
+
+- **Description**: A clear and concise description of the bug.
+- **Steps to Reproduce**: Steps to replicate the issue.
+- **Expected Behavior**: What should happen.
+- **Actual Behavior**: What actually happens.
+- **Screenshots**: If applicable, attach screenshots.
+- **Environment**: Specify OS, browser, and versions.
+- **Type**: Select type `Bug`
+- **Project**: Select Project `Blocks Construct`
+
+
+### Submitting Pull Requests
+
+1. **Fork the Repository**: Click the "Fork" button at the top right of the repository page.
+2. **Clone Your Fork**: Clone your forked repository to your local machine.
+   ```bash
+   git clone https://github.com/your-username/blocks-genesis-net.git
+   cd blocks-genesis-net
+   ```
+3. **Create a Branch**: Create a new branch for your feature or bugfix.
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+4. **Make Changes**: Implement your changes in the codebase.
+5. **Commit Changes**: Follow the [Git Guidelines](#git-guidelines) for commit messages.
+6. **Push to GitHub**: Push your changes to your forked repository.
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+7. **Open a Pull Request**: Navigate to the original repository and click "New Pull Request".
+
+## Branching Strategy
+
+We follow **Git Flow** for branching:
+
+- `main`: Production-ready code.
+- `dev`: Active development branch.
+- `feature/*`: New features branching from `dev`.
+- `bugfix/*`: Bug fixes branching from `dev`.
+- `hotfix/*`: Emergency fixes branching from `main`.
+
+## Git Guidelines
+
+- **Use the Imperative Mood**: Start commit messages with a verb in the imperative mood (e.g., "add", "fix", "update", "remove").
+- **Keep Messages Short and Descriptive**: The subject line should be concise (50 characters or less) and clearly describe the change.
+- **Separate Subject from Body**: If more detail is needed, separate the subject from the body with a blank line. The body should explain the "what" and "why" of the changes.
+- **Lowercase Commit Message**: Keep the commit message in lowercase.
+- **Avoid Ending with a Period**: Do not end the subject line with a period.
+- **Reference Issues and Pull Requests**: Reference related issues or pull requests in the body of the commit message (e.g., "fixes #123" or "see pr #456").
+- **Use Conventional Commits**: Follow the Conventional Commits specification for a standardized commit message format. Types include `feat`, `fix`, `docs`, `style`, `refactor` and `test`.
+
+Example of a well-structured commit message:
+```
+feat(auth): add user authentication - issue(#423)
+
+- implement JWT-based authentication
+- add login and registration endpoints
+- update user model to include password hashing
+```
+
+## Code Review Process
+
+All PRs undergo review to maintain quality. Review steps:
+
+1. **PR Submission**: Ensure PRs are small and well-documented.
+2. **Automated Checks**: CI/CD will run tests and linting.
+3. **Peer Review**: At least one maintainer must approve the PR.
+4. **Merge Process**: Once approved, the PR is merged into `dev`.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SELISE <Blocks/>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability, please report it to us as soon as possible. We take all reports seriously and will do our best to address the issue promptly.
+
+**Do not create a public GitHub issue for the security vulnerability.**
+
+Instead, please follow these steps:
+
+1. Email us at [blocks@selisegroup.com](mailto:blocks@selisegroup.com) with details of the vulnerability.
+2. Include a thorough description of the issue, including any relevant information on the environment in which the vulnerability was discovered.
+3. Allow some time for us to review and respond to your report.
+4. We will acknowledge receipt of your report and work with you to understand and validate the issue.
+
+## Responsible Disclosure
+
+We appreciate the efforts of security researchers and the community in helping to keep our project and users safe. If you responsibly disclose a security issue, we commit to:
+
+- Acknowledge and respond to your report promptly.
+- Work with you to understand and validate the issue.
+- Provide details on when and how the issue will be addressed.
+- Give credit to the reporter, if agreed upon, upon resolution of the issue.
+
+## Scope
+
+This security policy applies to the **SELISE `<Blocks/>`** project. Please note that this policy does not give you permission to hack, harm, or exploit our services. Any such attempts will be considered malicious and may be reported to the appropriate authorities.
+
+## Updates
+
+We may update this security policy from time to time. Check the file's Git history for the most recent changes.
+
+Thank you for helping to keep **SELISE `<Blocks/>`** secure!
+


### PR DESCRIPTION
Brings this repo's `.gitignore` up to the workspace baseline.

## What changed

Only the missing entries were added, so rules the repo already had are untouched.

```
# --- local AI / scan workspace (do not commit) ---
results/
.sonarqube/
scripts/scan.sh
*-secrets.json
.env
.env.*
!.env.example
# --- AI agent instruction files (do not commit) ---
QWEN.md
.clinerules
.windsurfrules
```

Agent instruction files are ignored defensively, so an assistant dropping one into the
tree cannot commit it by accident. The rest keeps generated and machine-local output out
of the repo.

## Verification

- Nothing currently tracked is shadowed by the new rules (`git ls-files | git check-ignore --stdin` is empty).
- Re-running the same fix adds nothing, so the change is idempotent.
- Code graph refreshed with `graphify update` before pushing.
- gitleaks run over the repo. No secret is introduced by this change.
